### PR TITLE
Making Http client futures configurable

### DIFF
--- a/components/wookiee-spray/src/main/resources/reference.conf
+++ b/components/wookiee-spray/src/main/resources/reference.conf
@@ -5,6 +5,7 @@ wookiee-spray {
 
   # The port to run the http server on
   http-port = 8080
+  client.timeout = 60s
 
   # The port to run the websocket server on
   websocket-port = 8081

--- a/components/wookiee-spray/src/main/scala/com/webtrends/harness/component/spray/SprayManager.scala
+++ b/components/wookiee-spray/src/main/scala/com/webtrends/harness/component/spray/SprayManager.scala
@@ -82,6 +82,8 @@ class SprayManager(name:String) extends Component(name)
 object SprayManager {
   def ComponentName = "wookiee-spray"
 
-  def KeyStaticRoot = "wookiee-spray.static-content.root-path"
-  def KeyStaticType = "wookiee-spray.static-content.type"
+  def KeyHttpClientTimeout = s"$ComponentName.client.timeout"
+
+  def KeyStaticRoot = s"$ComponentName.static-content.root-path"
+  def KeyStaticType = s"$ComponentName.static-content.type"
 }

--- a/components/wookiee-spray/src/main/scala/com/webtrends/harness/component/spray/client/CoreSprayClient.scala
+++ b/components/wookiee-spray/src/main/scala/com/webtrends/harness/component/spray/client/CoreSprayClient.scala
@@ -19,6 +19,8 @@
 package com.webtrends.harness.component.spray.client
 
 import com.webtrends.harness.app.HActor
+import com.webtrends.harness.component.spray.SprayManager
+import com.webtrends.harness.utils.ConfigUtil
 import spray.can.server.UHttp
 import spray.http._
 import akka.util.Timeout
@@ -50,6 +52,9 @@ object CoreSprayClient {
 class CoreSprayClient extends HActor with HttpLiftSupport {
   import context.dispatcher
   implicit val system:ActorSystem = context.system
+
+  // 60 seconds is the default that spray uses, so if the config value is not set we won't change the default
+  implicit val futureTimeout = ConfigUtil.getDefaultTimeout(context.system.settings.config, SprayManager.KeyHttpClientTimeout, 60 seconds)
 
   val pipeline:HttpRequest => Future[HttpResponse] = (
     encode(Gzip)


### PR DESCRIPTION
The default is 60 seconds, which is generally acceptable however if you need more time for some request you are out of luck. This will allow you to tweak this value in the unlikely event that you will need it.