### PR TITLE
Updates for Netty

### DIFF
--- a/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/BaseInboundHandler.scala
+++ b/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/BaseInboundHandler.scala
@@ -19,18 +19,17 @@
 
 package com.webtrends.harness.component.netty
 
+import com.webtrends.harness.component.netty.route.HandlerFunctions
 import com.webtrends.harness.logging.Logger
-import io.netty.buffer.Unpooled
-import io.netty.channel.{ChannelInboundHandlerAdapter, ChannelFutureListener, ChannelHandlerContext}
-import io.netty.handler.codec.http.HttpResponseStatus._
-import io.netty.handler.codec.http.{FullHttpResponse, HttpHeaders, DefaultFullHttpResponse, FullHttpRequest}
+import io.netty.channel.{ChannelInboundHandlerAdapter, ChannelHandlerContext}
+import io.netty.handler.codec.http.FullHttpRequest
 import io.netty.handler.codec.http.websocketx.{WebSocketFrame, WebSocketServerHandshaker}
-import io.netty.util.{ReferenceCountUtil, CharsetUtil}
+import io.netty.util.ReferenceCountUtil
 
 /**
  * Created by wallinm on 12/22/14.
  */
-abstract class BaseInboundHandler() extends ChannelInboundHandlerAdapter {
+abstract class BaseInboundHandler() extends ChannelInboundHandlerAdapter with HandlerFunctions {
 
   protected val log = Logger.getLogger(getClass)
   protected var handshaker: Option[WebSocketServerHandshaker] = None
@@ -39,87 +38,18 @@ abstract class BaseInboundHandler() extends ChannelInboundHandlerAdapter {
     var msgHandled = false
 
     try {
-    msg match {
-      // http requests
-      case req: FullHttpRequest => msgHandled = handleHttpRequest(ctx, req)
-      // websocket frames
-      case frame: WebSocketFrame => msgHandled = handleWebSocketFrame(ctx, frame)
-    }
-  } finally {
+      msg match {
+        // http requests
+        case req: FullHttpRequest => msgHandled = handleHttpRequest(ctx, req)
+        // websocket frames
+        case frame: WebSocketFrame => msgHandled = handleWebSocketFrame(ctx, frame)
+      }
+    } finally {
       if (!msgHandled) {
         ctx.fireChannelRead(msg)
       } else {
         ReferenceCountUtil.release(msg)
       }
-    }
-  }
-
-  /**
-   * Override this function in order to process http requests. 
-   * @param ctx
-   * @param req
-   * @return true if this function handled the request; otherwise, false
-   */
-  def handleHttpRequest(ctx: ChannelHandlerContext, req: FullHttpRequest): Boolean = {false}
-
-  /**
-   * Override this function in order to process websocket frames 
-   * @param ctx
-   * @param frame
-   * @return true if this function handled the frame; otherwise, false
-   */
-  def handleWebSocketFrame(ctx: ChannelHandlerContext, frame: WebSocketFrame): Boolean = {false}
-
-  /**
-   * Sends an HttpResponse 
-   * @param ctx ChannelHandlerContext
-   * @param req The request which is being responded to
-   * @param content The content for the response
-   * @param contentType The content type
-   */
-  def sendContent(ctx: ChannelHandlerContext, req: FullHttpRequest, content: String, contentType: String) {
-    val buf = Unpooled.copiedBuffer(content, CharsetUtil.UTF_8)
-    val res = new DefaultFullHttpResponse(req.getProtocolVersion, OK, buf)
-    res.headers().set(HttpHeaders.Names.CONTENT_TYPE, contentType.concat("; charset=UTF-8"))
-    sendHttpResponse(ctx, req, res)
-  }
-
-  /**
-   * Sends an HttpResponse with a status of 500
-   * @param ctx ChannelHandlerContext
-   * @param req The request which is being responded to
-   * @param error The error which caused the error response
-   */
-  def sendFailure(ctx: ChannelHandlerContext, req: FullHttpRequest, error: Throwable) {
-    val content = Unpooled.copiedBuffer(s"error: ${error.getMessage}", CharsetUtil.UTF_8)
-    val res = new DefaultFullHttpResponse(req.getProtocolVersion, INTERNAL_SERVER_ERROR, content)
-    res.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=UTF-8")
-    sendHttpResponse(ctx, req, res)
-  }
-
-  /**
-   * Sends an HttpResponse
-   * @param ctx ChannelHandlerContext
-   * @param req The request being responded to
-   * @param res The response to be sent
-   */
-  def sendHttpResponse(ctx: ChannelHandlerContext, req: FullHttpRequest, res: FullHttpResponse) {
-    val keepAlive = HttpHeaders.isKeepAlive(req)
-
-    HttpHeaders.setContentLength(res, res.content().readableBytes())
-
-    res.getStatus.code match {
-      case 200 =>
-      case _ =>
-        val buf = Unpooled.copiedBuffer(res.getStatus.toString, CharsetUtil.UTF_8)
-        res.content().writeBytes(buf)
-        buf.release()
-        HttpHeaders.setContentLength(res, res.content().readableBytes())
-    }
-
-    val f = ctx.channel().writeAndFlush(res)
-    if (!keepAlive || res.getStatus.code() != 200) {
-      f.addListener(ChannelFutureListener.CLOSE)
     }
   }
 

--- a/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/handler/HandlerManager.scala
+++ b/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/handler/HandlerManager.scala
@@ -36,6 +36,11 @@ object HandlerManager {
     handlers += name -> handlerFunc
   }
 
+  def addGetHandler(name:String, channelHandler: ChannelHandler): Unit = {
+    val func = () => Map(name -> channelHandler)
+    handlers += name -> func
+  }
+
   def removeHandler(name: String, handler: ChannelHandler) = {
     log.debug(s"handler unregistered with handler manager [${handler.toString}]")
     handlers.remove(name)

--- a/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/route/HandlerFunctions.scala
+++ b/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/route/HandlerFunctions.scala
@@ -1,0 +1,86 @@
+package com.webtrends.harness.component.netty.route
+
+import io.netty.buffer.Unpooled
+import io.netty.channel.{ChannelFutureListener, ChannelHandlerContext}
+import io.netty.handler.codec.http.HttpResponseStatus._
+import io.netty.handler.codec.http.{FullHttpResponse, HttpHeaders, DefaultFullHttpResponse, FullHttpRequest}
+import io.netty.handler.codec.http.websocketx.WebSocketFrame
+import io.netty.util.CharsetUtil
+
+/**
+ * @author Michael Cuthbert on 6/4/15.
+ */
+trait HandlerFunctions {
+  /**
+   * Override this function in order to process http requests.
+   * @param ctx
+   * @param req
+   * @return true if this function handled the request; otherwise, false
+   */
+  def handleHttpRequest(ctx: ChannelHandlerContext, req: FullHttpRequest): Boolean = {false}
+
+  /**
+   * Override this function in order to process websocket frames
+   * @param ctx
+   * @param frame
+   * @return true if this function handled the frame; otherwise, false
+   */
+  def handleWebSocketFrame(ctx: ChannelHandlerContext, frame: WebSocketFrame): Boolean = {false}
+
+  /**
+   * Sends an HttpResponse
+   * @param ctx ChannelHandlerContext
+   * @param req The request which is being responded to
+   * @param content The content for the response
+   * @param contentType The content type
+   */
+  def sendContent(ctx: ChannelHandlerContext, req: FullHttpRequest, content: String, contentType: String) {
+    val buf = Unpooled.copiedBuffer(content, CharsetUtil.UTF_8)
+    val res = new DefaultFullHttpResponse(req.getProtocolVersion, OK, buf)
+    res.headers().set(HttpHeaders.Names.CONTENT_TYPE, contentType.concat("; charset=UTF-8"))
+    sendHttpResponse(ctx, req, res)
+  }
+
+  def sendNoContent(ctx: ChannelHandlerContext, req: FullHttpRequest) {
+    val res = new DefaultFullHttpResponse(req.getProtocolVersion, NO_CONTENT)
+    sendHttpResponse(ctx, req, res)
+  }
+  /**
+   * Sends an HttpResponse with a status of 500
+   * @param ctx ChannelHandlerContext
+   * @param req The request which is being responded to
+   * @param error The error which caused the error response
+   */
+  def sendFailure(ctx: ChannelHandlerContext, req: FullHttpRequest, error: Throwable) {
+    val content = Unpooled.copiedBuffer(s"error: ${error.getMessage}", CharsetUtil.UTF_8)
+    val res = new DefaultFullHttpResponse(req.getProtocolVersion, INTERNAL_SERVER_ERROR, content)
+    res.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=UTF-8")
+    sendHttpResponse(ctx, req, res)
+  }
+
+  /**
+   * Sends an HttpResponse
+   * @param ctx ChannelHandlerContext
+   * @param req The request being responded to
+   * @param res The response to be sent
+   */
+  def sendHttpResponse(ctx: ChannelHandlerContext, req: FullHttpRequest, res: FullHttpResponse) {
+    val keepAlive = HttpHeaders.isKeepAlive(req)
+
+    HttpHeaders.setContentLength(res, res.content().readableBytes())
+
+    res.getStatus.code match {
+      case 200 =>
+      case _ =>
+        val buf = Unpooled.copiedBuffer(res.getStatus.toString, CharsetUtil.UTF_8)
+        res.content().writeBytes(buf)
+        buf.release()
+        HttpHeaders.setContentLength(res, res.content().readableBytes())
+    }
+
+    val f = ctx.channel().writeAndFlush(res)
+    if (!keepAlive || res.getStatus.code() != 200) {
+      f.addListener(ChannelFutureListener.CLOSE)
+    }
+  }
+}

--- a/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/route/NettyCommand.scala
+++ b/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/route/NettyCommand.scala
@@ -1,0 +1,25 @@
+package com.webtrends.harness.component.netty.route
+
+import com.webtrends.harness.command.{CommandBean, Command}
+import com.webtrends.harness.component.netty.route.NettyCommand.HandleHttpRequest
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.http.FullHttpRequest
+
+/**
+ * @author Michael Cuthbert on 6/4/15.
+ */
+abstract class NettyCommand extends Command {
+  this:NettyRoutes =>
+
+  override def receive = super.receive orElse {
+    case HandleHttpRequest(ctx, req, bean) => handleHttpRequest(ctx, req, bean)
+  }
+
+  def handleHttpRequest(ctx:ChannelHandlerContext, req:FullHttpRequest, bean:Option[CommandBean]) = {
+    innerExecute(ctx, req, bean)
+  }
+}
+
+object NettyCommand {
+  case class HandleHttpRequest(ctx: ChannelHandlerContext, req: FullHttpRequest, bean:Option[CommandBean]=None)
+}

--- a/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/route/NettyRoutes.scala
+++ b/components/wookiee-netty/src/main/scala/com/webtrends/harness/component/netty/route/NettyRoutes.scala
@@ -1,0 +1,97 @@
+package com.webtrends.harness.component.netty.route
+
+import akka.actor.ActorRef
+import com.webtrends.harness.command.{CommandBean, CommandResponse, Command}
+import com.webtrends.harness.component.netty.BaseInboundHandler
+import com.webtrends.harness.component.netty.handler.HandlerManager
+import com.webtrends.harness.component.netty.route.NettyCommand.HandleHttpRequest
+import io.netty.channel.ChannelHandler.Sharable
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.http.{FullHttpRequest, HttpMethod}
+import io.netty.handler.codec.http.HttpMethod._
+
+import scala.util.{Success, Failure}
+
+/**
+ * @author Michael Cuthbert on 6/2/15.
+ */
+@Sharable
+private[route] class NettyHandler(commandRef:ActorRef, paths:Map[String, String], method:HttpMethod) extends BaseInboundHandler {
+  /**
+   * Override this function in order to process http requests.
+   * @param ctx
+   * @param req
+   * @return true if this function handled the request; otherwise, false
+   */
+  override def handleHttpRequest(ctx: ChannelHandlerContext, req: FullHttpRequest): Boolean = {
+    (req.getMethod, req.getUri) match {
+      case (this.method, path) =>
+        paths.foreach {
+          case (name, testPath) =>
+            Command.matchPath(testPath, path.substring(1)) match {
+              case Some(bean) =>
+                commandRef ! HandleHttpRequest(ctx, req, Some(bean))
+                return true
+              case None => // ignore and go on to the next path to match
+            }
+        }
+
+      case _ => // ignore and we will leave this as unhandled
+    }
+    return false
+  }
+}
+
+private[route] trait NettyRoutes extends HandlerFunctions {
+  this:Command =>
+  import context.dispatcher
+
+  def innerExecute[T<:AnyRef:Manifest](ctx:ChannelHandlerContext, req:FullHttpRequest, bean:Option[CommandBean]) = {
+    execute(bean).mapTo[CommandResponse[T]] onComplete {
+      case Success(s) =>
+        s.data match {
+          case Some(value) => sendContent(ctx, req, value.toString, s.responseType)
+          case None => sendNoContent(ctx, req)
+        }
+
+      case Failure(f) => sendFailure(ctx, req, f)
+    }
+  }
+}
+
+trait NettyGet extends NettyRoutes {
+  this:NettyCommand =>
+  HandlerManager.addGetHandler(s"${commandName}_GET", new NettyHandler(self, paths, GET))
+}
+
+trait NettyPut extends NettyRoutes {
+  this:NettyCommand =>
+  HandlerManager.addGetHandler(s"${commandName}_PUT", new NettyHandler(self, paths, PUT))
+}
+
+trait NettyPost extends NettyRoutes {
+  this:NettyCommand =>
+  HandlerManager.addGetHandler(s"${commandName}_POST", new NettyHandler(self, paths, POST))
+}
+
+trait NettyOptions extends NettyRoutes {
+  this:NettyCommand =>
+  HandlerManager.addGetHandler(s"${commandName}_OPTIONS", new NettyHandler(self, paths, OPTIONS))
+}
+
+trait NettyHead extends NettyRoutes {
+  this:NettyCommand =>
+  HandlerManager.addGetHandler(s"${commandName}_HEAD", new NettyHandler(self, paths, HEAD))
+}
+
+trait NettyPatch extends NettyRoutes {
+  this:NettyCommand =>
+  HandlerManager.addGetHandler(s"${commandName}_PATCH", new NettyHandler(self, paths, PATCH))
+}
+
+trait NettyDelete extends NettyRoutes {
+  this:NettyCommand =>
+  HandlerManager.addGetHandler(s"${commandName}_DELETE", new NettyHandler(self, paths, DELETE))
+}
+
+

--- a/wookiee-core/src/main/scala/com/webtrends/harness/command/Command.scala
+++ b/wookiee-core/src/main/scala/com/webtrends/harness/command/Command.scala
@@ -37,7 +37,6 @@ trait Command extends HActor {
 
   override def receive = health orElse ({
     case ExecuteCommand(name, bean) => pipe(execute(bean)) to sender
-    case _ => // ignore all other messages to this actor
   } : Receive)
 
   def path : String = s"_wt_internal/${commandName.toLowerCase}"

--- a/wookiee-test/src/main/scala/com/webtrends/harness/service/test/BaseSpecTest.scala
+++ b/wookiee-test/src/main/scala/com/webtrends/harness/service/test/BaseSpecTest.scala
@@ -16,5 +16,5 @@ trait BaseSpecTest extends SpecificationLike {
 
   TestHarness(config, servicesMap, componentMap, Level.ALL)
   Thread.sleep(1000)
-  implicit val actorSystem = TestHarness.system.get
+  implicit val system = TestHarness.system.get
 }


### PR DESCRIPTION
This is really just a skeleton for the http traits in Netty. It only supports GET and basic marshalling, really just the very basics. Any major usage of it would require various updates to support things like custom headers, entities and more.